### PR TITLE
Fix external_data parameter

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/adroll-tag'
 versions:
+  - sha: e269d2d8c2ca3bfa36a7e97b51a5eb37223afdfc
+    changeNotes: Fixed external_data parameter location.
   - sha: 363c053d14f13394eb8a46f54127131de589b55b
     changeNotes: Improved consistency. Added tests.
   - sha: c16c272d315ae7ba4173c1e4c1f31bc41b554cb9

--- a/template.js
+++ b/template.js
@@ -82,12 +82,12 @@ function areThereRequiredFieldsMissing(mappedEventData) {
 }
 
 function getPostUrl() {
+  const isTestMode = [true, 'true'].indexOf(data.testMode) !== -1;
   return (
     'https://srv.adroll.com/api?' +
     'advertisable=' +
     enc(data.advertisableId) +
-    '&dry_run=' +
-    (data.testMode ? '1' : '0')
+    (isTestMode ? '&dry_run=1' : '')
   );
 }
 
@@ -318,16 +318,16 @@ function addCustomData(eventData, mappedData) {
   if (eventData.currency) mappedData.currency = eventData.currency;
   else if (currencyFromItems) mappedData.currency = currencyFromItems;
 
+  if (eventData.external_data) mappedData.external_data = eventData.external_data;
+
   if (eventData.search_term) mappedData.event_attributes.keywords = eventData.search_term;
 
   if (eventData.transaction_id) mappedData.event_attributes.order_id = eventData.transaction_id;
 
-  if (eventData.external_data) mappedData.event_attributes.external_data = eventData.external_data;
-
   if (data.customDataList) {
     data.customDataList.forEach((d) => {
       // These go in the 'event_attributes' object.
-      if (['order_id', 'products', 'keywords', 'external_data'].indexOf(d.name) !== -1)
+      if (['order_id', 'products', 'keywords'].indexOf(d.name) !== -1)
         mappedData.event_attributes[d.name] = d.value;
       else mappedData[d.name] = d.value;
     });

--- a/template.tpl
+++ b/template.tpl
@@ -147,11 +147,23 @@ ___TEMPLATE_PARAMETERS___
     "canBeEmptyString": true
   },
   {
-    "type": "CHECKBOX",
+    "type": "SELECT",
     "name": "testMode",
-    "checkboxText": "Test Mode",
+    "displayName": "Test Mode",
+    "macrosInSelect": true,
+    "selectItems": [
+      {
+        "value": false,
+        "displayValue": "False"
+      },
+      {
+        "value": true,
+        "displayValue": "True"
+      }
+    ],
     "simpleValueType": true,
-    "help": "If checked, the event will not be recorded but the API will still return the same response messages. Use this mode to verify your requests are working and your events are constructed correctly."
+    "help": "If checked, the event will not be recorded but the API will still return the same response messages. Use this mode to verify your requests are working and your events are constructed correctly.",
+    "defaultValue": false
   },
   {
     "type": "CHECKBOX",
@@ -596,12 +608,12 @@ function areThereRequiredFieldsMissing(mappedEventData) {
 }
 
 function getPostUrl() {
+  const isTestMode = [true, 'true'].indexOf(data.testMode) !== -1;
   return (
     'https://srv.adroll.com/api?' +
     'advertisable=' +
     enc(data.advertisableId) +
-    '&dry_run=' +
-    (data.testMode ? '1' : '0')
+    (isTestMode ? '&dry_run=1' : '')
   );
 }
 
@@ -832,16 +844,16 @@ function addCustomData(eventData, mappedData) {
   if (eventData.currency) mappedData.currency = eventData.currency;
   else if (currencyFromItems) mappedData.currency = currencyFromItems;
 
+  if (eventData.external_data) mappedData.external_data = eventData.external_data;
+
   if (eventData.search_term) mappedData.event_attributes.keywords = eventData.search_term;
 
   if (eventData.transaction_id) mappedData.event_attributes.order_id = eventData.transaction_id;
 
-  if (eventData.external_data) mappedData.event_attributes.external_data = eventData.external_data;
-
   if (data.customDataList) {
     data.customDataList.forEach((d) => {
       // These go in the 'event_attributes' object.
-      if (['order_id', 'products', 'keywords', 'external_data'].indexOf(d.name) !== -1)
+      if (['order_id', 'products', 'keywords'].indexOf(d.name) !== -1)
         mappedData.event_attributes[d.name] = d.value;
       else mappedData[d.name] = d.value;
     });
@@ -1631,7 +1643,7 @@ setup: |-
   const JSON = require('JSON');
 
   const expectedValue = 'test';
-  const expectedRequestUrl = 'https://srv.adroll.com/api?advertisable=' + expectedValue + '&dry_run=0';
+  const expectedRequestUrl = 'https://srv.adroll.com/api?advertisable=' + expectedValue;
   const expectedRequestOptions = {
     headers: {
       'Content-Type': 'application/json',
@@ -1653,8 +1665,7 @@ setup: |-
           "price": expectedValue
         }
       ],
-      "keywords": expectedValue,
-      "external_data": expectedValue
+      "keywords": expectedValue
     },
     "identifiers": {
       "first_party_cookie": expectedValue,
@@ -1674,7 +1685,8 @@ setup: |-
     "page_location": expectedValue,
     "timestamp": expectedValue,
     "conversion_value": expectedValue,
-    "currency": expectedValue
+    "currency": expectedValue,
+    "external_data": expectedValue
   };
 
   const mockData = {


### PR DESCRIPTION
Hi.

As clarified by AdRoll after raising a question about an ambiguity in their documentation, the `external_data` parameter must go in the **root** level instead of inside the `event_attributes` object. This PR fixes this. [[1]](https://github.com/stape-io/adroll-tag/pull/5/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R321) [[2]](https://github.com/stape-io/adroll-tag/pull/5/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L330)

I also changed the way the test mode is handled: changed the checkbox to a drop-down and changed how we pass this information in the request. [[1]](https://github.com/stape-io/adroll-tag/pull/5/files#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L150-R166) [[2]](https://github.com/stape-io/adroll-tag/pull/5/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L89-R90)